### PR TITLE
Remove verify param from jwt.decode call

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,10 +6,10 @@ name: Test and Analysis
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,13 @@
 
 name: Test and Analysis
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:

--- a/aad_token_verify/token_verifier.py
+++ b/aad_token_verify/token_verifier.py
@@ -33,7 +33,6 @@ def get_verified_payload(token: str, tenant_id: str = "common", audience_uris: L
         payload = decode(
             token,
             public_key,
-            verify=True,
             algorithms=["RS256"],
             audience=audience_uris,
             issuer=openid_config.get("issuer"),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with io.open(os.path.join(dir, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aad-token-verify',
-    version='0.1.3',
+    version='0.1.4',
     description='A python utility library to verify an Azure Active Directory OAuth token',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The pyjwt project deprecated the `verify` parameter to `jwt.decode` and now passing `verify=True` causes an error. Remove that parameter.