### PR TITLE
chore: Updating Dependencies

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,9 +11,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install build tools

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with io.open(os.path.join(dir, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aad-token-verify',
-    version='0.1.4',
+    version='0.2.0',
     description='A python utility library to verify an Azure Active Directory OAuth token',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -28,12 +28,12 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'requests>=2.25.1,<3',
         'PyJWT>=2.1.0,<3',
-        'cryptography>=3.3.2<4',
-        'cachetools>=4.2.2,<5'
+        'cryptography>=41.0.1,<42',
+        'cachetools>=5.3.1,<6'
     ],
     keywords='azure ad token oauth verify jwt',
     packages=['aad_token_verify'],


### PR DESCRIPTION
* Removed Python 3.6 from supported versions
* `cryptography` to `>=41.0.1,<42`
* `cachetools` to `>=5.3.1,<6`
* GitHub Actions workflow updates