### PR TITLE
Fix typo in code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ async def get_current_user(
     scheme, _, token = auth_header.partition(" ")
     return get_verified_payload(
         token,
-        tenantId=_TENANT_ID,
+        tenant_id=_TENANT_ID,
         audience_uris=[_AUDIENCE_URI],
     )
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change corrects a parameter name in the `get_current_user` function.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R57): Changed `tenantId` to `tenant_id` in the `get_current_user` function to follow consistent naming conventions.